### PR TITLE
Rolled back helm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Azure CLI 2.0.66
 - Terraform 0.12.17
 - Az Powershell Module 2.2.0 
-- Helm 3.0.3
+- Helm 2.16.1
 - kubectl 1.17.2
 
 ## Build

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsof
     pwsh -Command "Install-Module -Name Az -AllowClobber -Force"
     
 # Install helm/tiller
-RUN HELM_VERSION=v3.0.3 && \
+RUN HELM_VERSION=v2.16.1 && \
     wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz --no-check-certificate && \
     helm_sha256=7eebaaa2da4734242bbcdced62cc32ba8c7164a18792c8acdf16c77abffce202 && \
     echo "$helm_sha256 helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
Rolled back Helm to v2.16.1 as 3.0.3 failed the docker build due to checksum failure